### PR TITLE
add support for HTTP PATCH requests

### DIFF
--- a/mallory/request_handler.py
+++ b/mallory/request_handler.py
@@ -89,4 +89,4 @@ class RequestHandler(tornado.web.RequestHandler):
         self.write(message)
         self.finish()
 
-    get = post = put = delete = head = handle_request
+    get = post = put = delete = head = patch = handle_request

--- a/test/echo_request_handler.py
+++ b/test/echo_request_handler.py
@@ -48,7 +48,7 @@ class EchoRequestHandler(tornado.web.RequestHandler):
         except Exception as e:
             print "Unexpected test harness error:", e
 
-    get = post = head = delete = put = handle_request
+    get = post = head = delete = put = patch = handle_request
 
     def _request_summary(self):
         return "(Echo Handler) %s %s (%s)" % (self.request.method,  self.request.path, self.request.remote_ip)

--- a/test/mallory_test.py
+++ b/test/mallory_test.py
@@ -118,6 +118,13 @@ class MalloryTest(tornado.testing.AsyncTestCase):
         self.assertTrue(response.body.find("METHOD: PUT") >= 0, response.body)
         self.assertTrue(response.body.find("BODY: the put body") >= 0, response.body)
 
+    def test_patch(self):
+        http_client = tornado.httpclient.AsyncHTTPClient()
+        http_client.fetch(self.get_url("/"), self.stop, method = "PATCH", body = "the patch body", ca_certs = "test/ssl/mallory/server.crt")
+        response = self.wait()
+        self.assertTrue(response.body.find("METHOD: PATCH") >= 0, response.body)
+        self.assertTrue(response.body.find("BODY: the patch body") >= 0, response.body)
+
     def test_delete(self):
         http_client = tornado.httpclient.AsyncHTTPClient()
         http_client.fetch(self.get_url("/"), self.stop, method = "DELETE", ca_certs = "test/ssl/mallory/server.crt")


### PR DESCRIPTION
This PR adds PATCH to list of explicitly supported HTTP verbs.
